### PR TITLE
BC-2646 Bugfix/remove non json stdout

### DIFF
--- a/shared/nodes.py
+++ b/shared/nodes.py
@@ -811,12 +811,6 @@ class Redshift(Leaf):
         for vpc in parent.children:
             if vpc.local_id == json_blob["VpcId"]:
                 self._parent = vpc
-        if self._parent is None:
-            print(
-                "Could not find parent for Redshift node, was looking for VPC {}".format(
-                    json_blob["VpcId"]
-                )
-            )
 
         self._local_id = json_blob["ClusterIdentifier"]
         self._arn = json_blob["Endpoint"]["Address"]


### PR DESCRIPTION
https://bridgecrew.atlassian.net/browse/BC-2646

For an account / region with Redshift clusters, the find_unused command results in an (unimportant) error message being printed alongside the JSON, resulting in invalid JSON. This breaks parsing downstream.

I think this change is safe. There is other logic in the same file that tries to set the "parent" in the same way, but it doesn't print anything.